### PR TITLE
Improved design

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run `ng build` to build the project. The build artifacts will be stored in the `
 ## Release (prod) build
 
 - Switch to the `release` branch and merge `master` in (be sure to fetch/rebase upstream first).
-- Run `ng build -prod`
+- Run `ng build -prod --aot=false`
 - Commit and push to upstream's release
 
 ## Running unit tests

--- a/metrics/.angular-cli.json
+++ b/metrics/.angular-cli.json
@@ -27,6 +27,7 @@
         "../node_modules/d3/d3.min.js",
         "../node_modules/d3-tip/index.js",
         "../node_modules/moment/moment.js",
+        "../node_modules/jquery/dist/jquery.min.js",
         "../node_modules/patternfly/dist/js/patternfly.min.js"
       ],
       "environmentSource": "environments/environment.ts",

--- a/metrics/src/app/app.component.html
+++ b/metrics/src/app/app.component.html
@@ -27,10 +27,19 @@
       <a [routerLink]="['/r/metrics', {tenant: tenant}]">
         <span class="fa fa-line-chart" title="Metrics"></span>
         <span class="list-group-item-value">Metrics</span>
+        <a class="menu-item-button" (click)="refresh($event)">
+          <span class="fa fa-refresh"></span>
+        </a>
       </a>
       <div class="sidebar-inner">
         <metrics-list></metrics-list>
       </div>
+    </li>
+    <li *ngIf="!tenant" class="list-group-item disabled" title="You must configure a tenant">
+      <a>
+        <span class="fa fa-line-chart"></span>
+        <span class="list-group-item-value">Metrics</span>
+      </a>
     </li>
   </ul>
   <div class="alert alert-info alert-dismissable" *ngIf="showGrafanaAlert">

--- a/metrics/src/app/app.component.ts
+++ b/metrics/src/app/app.component.ts
@@ -30,4 +30,12 @@ export class AppComponent {
   constructor (private configService: HawkularConfigService) {
     configService.observeConfig().subscribe(cfg => this.tenant = cfg.tenant);
   }
+
+  refresh(event) {
+    // Simulate a config change so that config subscribers force refresh
+    this.configService.set(this.configService.get());
+    // Not sure why, we need "stopPropagation" AND return false to prevent the parent routerLink to be activated
+    event.stopPropagation();
+    return false;
+  }
 }

--- a/metrics/src/app/chart.component.html
+++ b/metrics/src/app/chart.component.html
@@ -5,12 +5,19 @@
     Tenant: {{hawkularConfig.tenant}}<br/>
     Metric type: {{type}}
   </p>
-  <h3>{{notice}}</h3>
+  <div class="alert alert-warning" *ngIf="warning">
+    <span class="pficon pficon-warning-triangle-o"></span>
+    {{warning}}
+  </div>
+  <div class="alert alert-info" *ngIf="notice">
+    <span class="pficon pficon-info"></span>
+    {{notice}}
+  </div>
   <div class="row toolbar-pf">
     <div class="col-sm-12">
       <form class="toolbar-pf-actions">
         <div class="form-group">
-          <select [(ngModel)]="timeframe" (ngModelChange)="onTimeFrameChanged($event)" [ngModelOptions]="{standalone: true}">
+          <select class="form-control" [(ngModel)]="timeframe" (ngModelChange)="onTimeFrameChanged($event)" [ngModelOptions]="{standalone: true}">
             <option value='5m'>Last 5 minutes</option>
             <option value='15m'>Last 15 minutes</option>
             <option value='30m'>Last 30 minutes</option>
@@ -23,9 +30,9 @@
             <option value='custom' disabled=true>Custom</option>
           </select>
         </div>
-        <div class="form-group">
-          <span>Refresh rate:</span>
-          <select [(ngModel)]="refreshRate" [ngModelOptions]="{standalone: true}">
+        <div class="form-group form-inline">
+          <label class="control-label" for="refresh">Refresh rate</label>
+          <select id="refresh" class="form-control" [(ngModel)]="refreshRate" [ngModelOptions]="{standalone: true}">
             <option value='5'>5 seconds</option>
             <option value='10'>10 seconds</option>
             <option value='30'>30 seconds</option>
@@ -34,8 +41,8 @@
           </select>
         </div>
         <div class="form-group">
-          <input type="checkbox" class="checkbox-inline" [(ngModel)]="useRawData" [ngModelOptions]="{standalone: true}">
-          <span>Raw data</span>
+          <input id="raw" type="checkbox" class="checkbox-inline" [(ngModel)]="useRawData" [ngModelOptions]="{standalone: true}">
+          <label class="control-label" for="raw">Raw data</label>
         </div>
       </form>
     </div>

--- a/metrics/src/app/chart.component.ts
+++ b/metrics/src/app/chart.component.ts
@@ -29,8 +29,9 @@ import { Configuration } from './model/configuration';
 })
 export class ChartComponent implements OnInit, OnChanges {
   timeframe: string = '6h';
-  refreshRate = 5;
+  refreshRate = 30;
   notice: string = '';
+  warning: string = '';
   hawkularConfig: Configuration;
   type: string;
   metric: string;
@@ -65,12 +66,13 @@ export class ChartComponent implements OnInit, OnChanges {
 
   refreshComputedVars() {
     this.notice = '';
+    this.warning = '';
     this.displayChart = false;
     if (!this.hawkularConfig.tenant) {
-      this.notice = 'The tenant is not configured';
+      this.warning = 'The tenant is not configured';
     } else if (this.type && this.metric) {
       if (this.type === 'availability' || this.type === 'string') {
-        this.notice = 'Availability and String metrics cannot be displayed at this time';
+        this.warning = 'Availability and String metrics cannot be displayed at this time';
       } else {
         this.displayChart = true;
       }

--- a/metrics/src/app/config-page.component.html
+++ b/metrics/src/app/config-page.component.html
@@ -37,7 +37,7 @@
     <div class="form-group">
       <div class="col-sm-offset-3 col-sm-10">
         <button type="submit" class="btn btn-primary">Save<span *ngIf="changed">*</span></button>
-        <button class="btn btn-default" (click)="onReset($event)">Reset</button>
+        <button *ngIf="changed" class="btn btn-default" (click)="onReset($event)">Reset</button>
       </div>
     </div>
   </form>

--- a/metrics/src/app/metrics-list.component.ts
+++ b/metrics/src/app/metrics-list.component.ts
@@ -41,17 +41,22 @@ export class MetricsListComponent {
   }
 
   fetchMetrics(headers: Headers) {
-    this.loading = true;
+    const h = setTimeout(() => this.loading = true, 500);
     this.message = '';
+    this.metrics = [];
     if (!headers) {
-      this.metrics = [];
       this.message = 'The tenant is not configured';
+      clearTimeout(h);
+      this.loading = false;
       return;
     }
     const options = new RequestOptions({ headers: headers });
     this.http.get(environment.metricsURL + '/metrics', options)
       .map((response) => response.json())
-      .finally(() => this.loading = false)
+      .finally(() => {
+        clearTimeout(h);
+        this.loading = false;
+      })
       .subscribe((metrics: Metric[]) => {
         if (metrics && metrics.length > 0) {
           this.metrics = metrics.sort((a,b) => {
@@ -62,11 +67,9 @@ export class MetricsListComponent {
           });
           this.message = '';
         } else {
-          this.metrics = [];
           this.message = 'No metric found for this tenant';
         }
       }, (err) => {
-        this.metrics = [];
         if (err.status == 0 && err.statusText == '') {
           this.message = 'Could not connect to the server';
         } else {

--- a/metrics/src/styles.css
+++ b/metrics/src/styles.css
@@ -31,6 +31,39 @@
     text-decoration: none;
 }
 
+.list-group-item.disabled:hover,
+.list-group-item.disabled:focus {
+    /* Missing in Patternfly? */
+    background-color: inherit;
+}
+
+.list-group-item.disabled:hover>a {
+    /* Missing in Patternfly? */
+    cursor: not-allowed;
+    color: #d1d1d1;
+    background-color: inherit;
+    font-weight: inherit;
+}
+
+.list-group-item.disabled:hover>a .fa {
+    /* Missing in Patternfly? */
+    color: #72767b;
+    background-color: inherit;
+}
+
+.nav-pf-vertical .list-group-item>a>.menu-item-button {
+    background-color: transparent;
+}
+
+.nav-pf-vertical .list-group-item>a>.menu-item-button .fa {
+    font-size: 12px;
+    color: #72767b;
+}
+
+.nav-pf-vertical .list-group-item>a>.menu-item-button:hover .fa {
+    color: #39a5dc;
+}
+
 .sidebar .sidebar-inner ul {
     list-style: none;
     margin: 0 -20px 0 -20px;


### PR DESCRIPTION
- Adding a refresh button to fetch metrics list
- Loading spinner for metrics list now shows up only after 500ms
- Metrics list item is now displayed but disabled when tenant is not set
- Improved design of chart page (PF alerts, better dropdown lists)
- Config: hide reset button when there's nothing to reset
- Added jquery (needed by patternfly, console was showing an error)